### PR TITLE
package.json 내 불필요한 스크립트 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,6 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject",
-    "predeploy": "react-scripts build",
     "deploy": "gh-pages -d build"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -18,18 +18,6 @@
       "react-app"
     ]
   },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
   "devDependencies": {
     "gh-pages": "^6.1.1"
   },


### PR DESCRIPTION
## 배경
해당 프로젝트는 모든 브라우저에 대응되어야 하기에 `browserslist `는 필요없습니다.
실제 `npm start` `npm deploy` 외에는 사용될 일이 없어서 해당 명령어도 제거합니다,
추후 해당 명령어들이 필요하게 되면 그때 다시 선언 하겠습니다.

## 작업 내용
- `browserslist ` 제거
- 불필요한 script 명령어 제거